### PR TITLE
Feature/themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ go install github.com/nore-dev/fman@latest
 ## Keybindings
 
 |      Key      |                Description                |
-|:-------------:|:-----------------------------------------:|
+| :-----------: | :---------------------------------------: |
 |  `q, Ctrl+C`  |           Exit from application           |
 | `a, h, left`  |         Move to parent directory          |
 | `d, l, right` |        Move to selected directory         |
@@ -33,13 +33,23 @@ $ go install github.com/nore-dev/fman@latest
 |     `gg`      |     Move to the beginning of the list     |
 |      `m`      |        Toggle showing hidden Files        |
 |    `~, .`     |        Move to the home directory         |
+
+## CLI options
+
+|    Key    |   Type   |        Values        | Default value |
+| :-------: | :------: | :------------------: | :-----------: |
+| `--theme` | `string` | `darcula,brogrammer` |   `darcula`   |
+
 ## Built With
+
 Without these projects this project would not have existed at all.
+
 - [Bubbletea](https://github.com/charmbracelet/bubbletea/)
 - [Lipgloss](https://github.com/charmbracelet/lipgloss)
 - [Bubblezone](https://github.com/lrstanley/bubblezone)
 - [stickers](https://github.com/76creates/stickers)
 - [Chroma](https://github.com/alecthomas/chroma)
+- [go-arg](https://github.com/alexflint/go-arg)
 
 ## CONTRIBUTING
 
@@ -55,6 +65,7 @@ Don't forget to give the project a star! Thanks again!
 5. Open a Pull Request
 
 ## LICENSE
+
 Distributed under the MIT License. See `LICENSE` for more information.
 
 ## Acknowledgments

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 )
 
 require (
+	github.com/alexflint/go-arg v1.4.3 // indirect
+	github.com/alexflint/go-scalar v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/76creates/stickers v0.0.0-20220613133526-beb5a915bb0e h1:xjq+PbfrWmEF
 github.com/76creates/stickers v0.0.0-20220613133526-beb5a915bb0e/go.mod h1:z/6G23++VMIXkwi+nFfb4H6Y4dIo6UsHULeYPp2DAkQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/alexflint/go-arg v1.4.3 h1:9rwwEBpMXfKQKceuZfYcwuc/7YY7tWJbFsgG5cAU/uo=
+github.com/alexflint/go-arg v1.4.3/go.mod h1:3PZ/wp/8HuqRZMUUgu7I+e1qcpUbvmS258mRXkFH4IA=
+github.com/alexflint/go-scalar v1.1.0 h1:aaAouLLzI9TChcPXotr6gUhq+Scr8rl0P9P4PnltbhM=
+github.com/alexflint/go-scalar v1.1.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/charmbracelet/bubbletea v0.22.1 h1:z66q0LWdJNOWEH9zadiAIXp2GN1AWrwNXU8obVY9X24=
@@ -51,6 +55,7 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.3.4 h1:3Z3Eu6FGHZWSfNKJTOUiPatWwfc7DzJRU04jFUqJODw=
 github.com/rivo/uniseg v0.3.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/76creates/stickers"
+	"github.com/alexflint/go-arg"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	zone "github.com/lrstanley/bubblezone"
@@ -24,20 +24,7 @@ type App struct {
 }
 
 func (app *App) Init() tea.Cmd {
-	return tea.Batch(app.infobarModel.Init(), app.UpdatePath(), app.listModel.Init())
-}
-
-func (app *App) UpdatePath() tea.Cmd {
-	return func() tea.Msg {
-		path := "."
-
-		if len(os.Args) >= 2 {
-			path = os.Args[1]
-		}
-
-		absolutePath, _ := filepath.Abs(path)
-		return model.PathMsg{Path: absolutePath}
-	}
+	return tea.Batch(app.infobarModel.Init(), app.listModel.Init())
 }
 
 func (app *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -94,14 +81,21 @@ func (app *App) View() string {
 	))
 }
 
+// Define CLI arguments
+var args struct {
+	Theme string `default:"default"`
+}
+
 func main() {
 	// Initialize Bubblezone
 	zone.NewGlobal()
 	defer zone.Close()
 
-	selectedTheme := theme.DefaultTheme
+	arg.MustParse(&args)
 
-	theme.SetTheme(theme.DefaultTheme)
+	selectedTheme := theme.Themes[args.Theme]
+
+	theme.SetTheme(selectedTheme)
 	listModel := model.NewListModel(&selectedTheme)
 
 	app := App{

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type App struct {
 }
 
 func (app *App) Init() tea.Cmd {
-	return tea.Batch(app.infobarModel.Init(), app.listModel.Init())
+	return tea.Batch(app.infobarModel.Init(), app.UpdatePath(), app.listModel.Init())
 }
 
 func (app *App) UpdatePath() tea.Cmd {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/76creates/stickers"
 	"github.com/alexflint/go-arg"
@@ -25,6 +26,15 @@ type App struct {
 
 func (app *App) Init() tea.Cmd {
 	return tea.Batch(app.infobarModel.Init(), app.listModel.Init())
+}
+
+func (app *App) UpdatePath() tea.Cmd {
+	return func() tea.Msg {
+		path := args.Path
+
+		absolutePath, _ := filepath.Abs(path)
+		return model.PathMsg{Path: absolutePath}
+	}
 }
 
 func (app *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -83,6 +93,7 @@ func (app *App) View() string {
 
 // Define CLI arguments
 var args struct {
+	Path  string `arg:"positional" default:"."`
 	Theme string `default:"default"`
 }
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	arg.MustParse(&args)
 
-	selectedTheme := theme.Themes[args.Theme]
+	selectedTheme := theme.GetActiveTheme(args.Theme)
 
 	theme.SetTheme(selectedTheme)
 	listModel := model.NewListModel(&selectedTheme)

--- a/theme/brogrammer.go
+++ b/theme/brogrammer.go
@@ -1,0 +1,31 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+var BrogrammerTheme = Theme{
+	EvenItemBgColor: lipgloss.Color("#44475a"),
+
+	SelectedItemBgColor: lipgloss.Color("#e67e22"),
+	SelectedItemFgColor: lipgloss.Color("#282a36"),
+
+	ButtonBgColor:       lipgloss.Color("#44475a"),
+	ButtonBorderFgColor: lipgloss.Color("#6272a4"),
+
+	PathElementBgColor:       lipgloss.Color("#44475a"),
+	PathElementFgColor:       lipgloss.Color("#f8f8f2"),
+	PathElementBorderFgColor: lipgloss.Color("#aaa"),
+
+	ListBgColor: lipgloss.Color("#1a1a1a"),
+	ListFgColor: lipgloss.Color("#ecf0f1"),
+
+	LogoBgColor: lipgloss.Color("#f1fa8c"),
+	LogoFgColor: lipgloss.Color("#282a36"),
+
+	ProgressBarBgColor: lipgloss.Color("#44475a"),
+	ProgressBarFgColor: lipgloss.Color("#ffb86c"),
+
+	HiddenFileColor:   lipgloss.Color("#8be9fd"),
+	HiddenFolderColor: lipgloss.Color("#bd93f9"),
+	FolderColor:       lipgloss.Color("#ffb86c"),
+	TextColor:         lipgloss.Color("#ddd"),
+}

--- a/theme/config.go
+++ b/theme/config.go
@@ -4,7 +4,7 @@ type ThemeMap map[string]Theme
 
 var themes = ThemeMap{
 	"default":    DefaultTheme,
-	"darcula":    DefaultTheme,
+	"dracula":    DefaultTheme,
 	"brogrammer": BrogrammerTheme,
 }
 

--- a/theme/config.go
+++ b/theme/config.go
@@ -2,8 +2,19 @@ package theme
 
 type ThemeMap map[string]Theme
 
-var Themes = ThemeMap{
+var themes = ThemeMap{
 	"default":    DefaultTheme,
 	"darcula":    DefaultTheme,
 	"brogrammer": BrogrammerTheme,
+}
+
+// Tries to match provided flag value for --theme against
+// an existing ThemeMap and returns default theme if theme
+// name does not match any records
+// in the ThemeMap (due to a typo for example)
+func GetActiveTheme(themeNameCandidate string) (theme Theme) {
+	if _, ok := themes[themeNameCandidate]; ok {
+		return themes[themeNameCandidate]
+	}
+	return DefaultTheme
 }

--- a/theme/config.go
+++ b/theme/config.go
@@ -1,0 +1,9 @@
+package theme
+
+type ThemeMap map[string]Theme
+
+var Themes = ThemeMap{
+	"default":    DefaultTheme,
+	"darcula":    DefaultTheme,
+	"brogrammer": BrogrammerTheme,
+}


### PR DESCRIPTION
### Topic
Proposal for handling themes.

### Notable changes
- Introduces CLI arguments handling with help of [go-arg](https://github.com/alexflint/go-arg)
- Adds a brogrammer theme option (in its current state it only resembles the brogrammer palette, I added it to showcase the ability of switching between themes)
- If no `--theme` option is provided then default theme is picked and displayed.

### Other changes
- Sorry for removing the `updatePath` function in `main.go` - it was the only way to make CLI arguments work and not break the filepaths. Everything seems to work properly, but please do tell if I made a mistake by removing it, I'm not too efficient with `bubbletea`.

Closes #21 

https://user-images.githubusercontent.com/8414298/194067786-6c24f52a-3287-41a4-b5b0-1d871ec50f90.mp4


