### PR TITLE
feat: add ability to specify icon sets with --icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ $ go install github.com/nore-dev/fman@latest
 
 ## :computer: CLI options
 
-|    Key    |   Type   |        Values        | Default value |
-| :-------: | :------: | :------------------: | :-----------: |
-| `--theme` | `string` | `dracula,brogrammer` |   `dracula`   |
+|        Key        |   Type   |        Values         | Default value |
+| :---------------: | :------: | :-------------------: | :-----------: |
+|     `--theme`     | `string` | `dracula,brogrammer`  |   `dracula`   |
+| `--icons` | `string` | `nerdfont,emoji,none` |  `nerdfont`   |
 
 ## :heart: Built With
 

--- a/args/arguments.go
+++ b/args/arguments.go
@@ -1,0 +1,15 @@
+package args
+
+import "github.com/alexflint/go-arg"
+
+// Define CommandLine arguments
+var CommandLine struct {
+	Path  string `arg:"positional" default:"."`
+	Theme string `default:"default"`
+	Icons string `default:"nerdfont"`
+}
+
+// Expose initialization function
+func Initialize() {
+	arg.MustParse(&CommandLine)
+}

--- a/main.go
+++ b/main.go
@@ -5,12 +5,12 @@ import (
 	"path/filepath"
 
 	"github.com/76creates/stickers"
-	"github.com/alexflint/go-arg"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/muesli/termenv"
 
+	"github.com/nore-dev/fman/args"
 	"github.com/nore-dev/fman/message"
 
 	"github.com/nore-dev/fman/model/entryinfo"
@@ -36,7 +36,7 @@ func (app *App) Init() tea.Cmd {
 
 func (app *App) UpdatePath() tea.Cmd {
 	return func() tea.Msg {
-		path := args.Path
+		path := args.CommandLine.Path
 
 		absolutePath, _ := filepath.Abs(path)
 		return message.PathMsg{Path: absolutePath}
@@ -98,20 +98,13 @@ func (app *App) View() string {
 	))
 }
 
-// Define CLI arguments
-var args struct {
-	Path  string `arg:"positional" default:"."`
-	Theme string `default:"default"`
-}
-
 func main() {
 	// Initialize Bubblezone
 	zone.NewGlobal()
 	defer zone.Close()
 
-	arg.MustParse(&args)
-
-	selectedTheme := theme.GetActiveTheme(args.Theme)
+	args.Initialize()
+	selectedTheme := theme.GetActiveTheme(args.CommandLine.Theme)
 
 	theme.SetTheme(selectedTheme)
 

--- a/model/breadcrumb/breadcrumb.go
+++ b/model/breadcrumb/breadcrumb.go
@@ -66,7 +66,7 @@ func (breadcrumb Breadcrumb) View() string {
 		strBuilder.WriteString(theme.PathStyle.Render(zone.Mark(strconv.Itoa(i), part)))
 
 		if i != len(pathParts)-1 {
-			strBuilder.WriteString(theme.ArrowStyle.Render(string(theme.BreadcrumbArrowIcon)))
+			strBuilder.WriteString(theme.ArrowStyle.Render(string(theme.GetActiveIconTheme().BreadcrumbArrowIcon)))
 		}
 	}
 

--- a/model/entryinfo/entryinfo.go
+++ b/model/entryinfo/entryinfo.go
@@ -155,11 +155,11 @@ func (entryInfo *EntryInfo) getFileInfo() string {
 			Width(lipgloss.Width(typeStr) + 2*padding + 2).
 			Foreground(entryInfo.theme.BackgroundColor)
 
-		icon := theme.FileIcon
+		icon := theme.GetActiveIconTheme().FileIcon
 
 		if entryInfo.entry.IsDir {
 			style.Background(entryInfo.theme.FolderColor)
-			icon = theme.FolderIcon
+			icon = theme.GetActiveIconTheme().FolderIcon
 		} else {
 			style.Background(entryInfo.theme.HiddenFileColor)
 		}

--- a/model/infobar/infobar.go
+++ b/model/infobar/infobar.go
@@ -81,7 +81,7 @@ func renderProgress(width int, usedSpace uint64, totalSpace uint64) string {
 func (infobar Infobar) View() string {
 
 	info := infobar.storageInfo
-	logo := theme.LogoStyle.Render(string(theme.GopherIcon) + "FMAN")
+	logo := theme.LogoStyle.Render(string(theme.GetActiveIconTheme().GopherIcon) + "FMAN")
 
 	progress := renderProgress(infobar.progressWidth, info.AvailableSpace, info.TotalSpace)
 

--- a/model/list/view.go
+++ b/model/list/view.go
@@ -19,15 +19,15 @@ func (list *List) View() string {
 	contents := make([]strings.Builder, cellsLength)
 
 	// Write List headers
-	contents[0].WriteRune(theme.NameIcon)
+	contents[0].WriteRune(theme.GetActiveIconTheme().NameIcon)
 	contents[0].WriteString(termenv.String(" Name").Italic().String())
 	contents[0].WriteByte('\n')
 
-	contents[1].WriteRune(theme.SizeIcon)
+	contents[1].WriteRune(theme.GetActiveIconTheme().SizeIcon)
 	contents[1].WriteString(termenv.String(" Size").Italic().String())
 	contents[1].WriteByte('\n')
 
-	contents[2].WriteRune(theme.TimeIcon)
+	contents[2].WriteRune(theme.GetActiveIconTheme().TimeIcon)
 	contents[2].WriteString(termenv.String(" Modify Time").Italic().String())
 	contents[2].WriteByte('\n')
 
@@ -46,11 +46,11 @@ func (list *List) View() string {
 		name := truncateText(entry.Name, list.truncateLimit-2)
 
 		if entry.SymlinkName != "" {
-			content[0].WriteRune(theme.SymlinkIcon)
+			content[0].WriteRune(theme.GetActiveIconTheme().SymlinkIcon)
 		} else if entry.IsDir {
-			content[0].WriteRune(theme.FolderIcon)
+			content[0].WriteRune(theme.GetActiveIconTheme().FolderIcon)
 		} else {
-			content[0].WriteRune(theme.FileIcon)
+			content[0].WriteRune(theme.GetActiveIconTheme().FileIcon)
 		}
 
 		content[0].WriteRune(' ')

--- a/model/toolbar/toolbar.go
+++ b/model/toolbar/toolbar.go
@@ -55,10 +55,9 @@ func (toolbar *Toolbar) Update(msg tea.Msg) (Toolbar, tea.Cmd) {
 }
 
 func (toolbar *Toolbar) View() string {
-
 	view := lipgloss.JoinHorizontal(lipgloss.Left,
-		zone.Mark("back", theme.ButtonStyle.Render(string(theme.LeftArrowIcon))),
-		zone.Mark("forward", theme.ButtonStyle.Render(string(theme.RightArrowIcon))),
+		zone.Mark("back", theme.ButtonStyle.Render(string(theme.GetActiveIconTheme().LeftArrowIcon))),
+		zone.Mark("forward", theme.ButtonStyle.Render(string(theme.GetActiveIconTheme().RightArrowIcon))),
 	)
 
 	return lipgloss.JoinHorizontal(lipgloss.Center, view, toolbar.breadcrumb.View())

--- a/theme/icon.go
+++ b/theme/icon.go
@@ -1,17 +1,65 @@
 package theme
 
-const (
-	LeftArrowIcon       rune = '\uf060'
-	RightArrowIcon      rune = '\uf061'
-	BreadcrumbArrowIcon rune = '\uf0a4'
-
-	GopherIcon rune = '\ue627'
-
-	FileIcon    rune = '\uf15c'
-	FolderIcon  rune = '\uf07b'
-	SymlinkIcon rune = '\uf838'
-
-	TimeIcon rune = '\uf017'
-	SizeIcon rune = '\uf200'
-	NameIcon rune = '\ue612'
+import (
+	"github.com/nore-dev/fman/args"
 )
+
+type iconSet struct {
+	LeftArrowIcon       rune
+	RightArrowIcon      rune
+	BreadcrumbArrowIcon rune
+
+	GopherIcon rune
+
+	FileIcon    rune
+	FolderIcon  rune
+	SymlinkIcon rune
+
+	TimeIcon rune
+	SizeIcon rune
+	NameIcon rune
+}
+
+type iconSets map[string]iconSet
+
+var nerdFont = iconSet{
+	LeftArrowIcon:       '\uf060',
+	RightArrowIcon:      '\uf061',
+	BreadcrumbArrowIcon: '\uf0a4',
+	GopherIcon:          '\ue627',
+	FileIcon:            '\uf15c',
+	FolderIcon:          '\uf07b',
+	SymlinkIcon:         '\uf838',
+	TimeIcon:            '\uf017',
+	SizeIcon:            '\uf200',
+	NameIcon:            '\ue612',
+}
+
+var emoji = iconSet{
+	LeftArrowIcon:       '◀',
+	RightArrowIcon:      '▶',
+	BreadcrumbArrowIcon: '👉',
+	GopherIcon:          '🐻',
+	FileIcon:            '📄',
+	FolderIcon:          '📁',
+	SymlinkIcon:         '🔗',
+	TimeIcon:            '⏰',
+	SizeIcon:            '📊',
+	NameIcon:            '🏷',
+}
+
+var noIcons = iconSet{
+	LeftArrowIcon:       '<',
+	RightArrowIcon:      '>',
+	BreadcrumbArrowIcon: '>',
+}
+
+var iconProviders = iconSets{
+	"emoji":    emoji,
+	"nerdfont": nerdFont,
+	"none":     noIcons,
+}
+
+func GetActiveIconTheme() iconSet {
+	return iconProviders[args.CommandLine.Icons]
+}


### PR DESCRIPTION
- Added ability to specify an icon set with `--icons` CLI options.
- Moved CLI args handling into a separate package, making it easier to reuse CLI flags across the app.

`--icons=emoji`
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/8414298/195868018-d3710638-f671-45dd-b95d-8366e8e4f2d1.png">


`--icons=none`
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/8414298/195867929-1744a459-ff1f-4062-b72a-a6d867359e4a.png">
