### PR TITLE
feat: added support for a toml config file

### DIFF
--- a/args/arguments.go
+++ b/args/arguments.go
@@ -5,8 +5,8 @@ import "github.com/alexflint/go-arg"
 // Define CommandLine arguments
 var CommandLine struct {
 	Path  string `arg:"positional" default:"."`
-	Theme string `default:"default"`
-	Icons string `default:"nerdfont"`
+	Theme string `default:""`
+	Icons string `default:""`
 }
 
 // Expose initialization function

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1,0 +1,75 @@
+package cfg
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/nore-dev/fman/args"
+)
+
+const (
+	// Config Metadata
+	XdgConfigDir       = "/.config/"
+	FmanConfigDir      = "/.config/fman/"
+	FmanConfigFileName = "config.toml"
+
+	// Config Defaults
+	DefaultTheme = "default"
+	DefaultIcons = "nerdfont"
+)
+
+var Config = &Cfg{}
+
+type Cfg struct {
+	Theme string
+	Icons string
+}
+
+func LoadConfig() error {
+	// Load file if exists
+	err := loadConfigFile()
+
+	// If config file exists and cli args are provided use args from cli
+	if args.CommandLine.Theme != "" {
+		Config.Theme = args.CommandLine.Theme
+	}
+	if args.CommandLine.Icons != "" {
+		Config.Icons = args.CommandLine.Icons
+	}
+
+	// For each config value if neither config file or cli args provides a value
+	// then use default values to fill config object.
+	if Config.Theme == "" {
+		Config.Theme = DefaultTheme
+	}
+	if Config.Icons == "" {
+		Config.Icons = DefaultIcons
+	}
+
+	return err
+}
+
+func loadConfigFile() error {
+	currentUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	fileContents, err := os.ReadFile(filepath.Join(currentUser.HomeDir, FmanConfigDir, FmanConfigFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.New("no config file found")
+		} else {
+			return errors.New("could not read config file")
+		}
+	}
+	_, err = toml.Decode(string(fileContents), Config)
+	if err != nil {
+		return errors.New("could not decode config file")
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/alexflint/go-scalar v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/76creates/stickers v0.0.0-20220613133526-beb5a915bb0e h1:xjq+PbfrWmEF1N9oHyZla/uy5oDgHy3TUtKCi6Ud3Ak=
 github.com/76creates/stickers v0.0.0-20220613133526-beb5a915bb0e/go.mod h1:z/6G23++VMIXkwi+nFfb4H6Y4dIo6UsHULeYPp2DAkQ=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alexflint/go-arg v1.4.3 h1:9rwwEBpMXfKQKceuZfYcwuc/7YY7tWJbFsgG5cAU/uo=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/muesli/termenv"
+	"github.com/nore-dev/fman/cfg"
 
 	"github.com/nore-dev/fman/args"
 	"github.com/nore-dev/fman/keymap"
@@ -156,7 +158,11 @@ func main() {
 	defer zone.Close()
 
 	args.Initialize()
-	selectedTheme := theme.GetActiveTheme(args.CommandLine.Theme)
+	err := cfg.LoadConfig() // TODO: show error somewhere
+	if err != nil {
+		log.Println(err)
+	}
+	selectedTheme := theme.GetActiveTheme(cfg.Config.Theme)
 
 	theme.SetTheme(selectedTheme)
 

--- a/theme/icon.go
+++ b/theme/icon.go
@@ -1,7 +1,7 @@
 package theme
 
 import (
-	"github.com/nore-dev/fman/args"
+	"github.com/nore-dev/fman/cfg"
 )
 
 type iconSet struct {
@@ -66,5 +66,5 @@ var iconProviders = iconSets{
 }
 
 func GetActiveIconTheme() iconSet {
-	return iconProviders[args.CommandLine.Icons]
+	return iconProviders[cfg.Config.Icons]
 }


### PR DESCRIPTION
This PR adds support for a toml config file per #47.

Changes:
 - If a config file exists in `~/.config/` load config
 - CLI args overide config file
 - Defaults are used if neither CLI args or config file are provided.