### PR TITLE
feat: configure GoRelease to publish to homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.so
 *.dylib
 
+.DS_Store
+
 # Test binary, built with `go test -c`
 *.test
 
@@ -19,3 +21,6 @@
 
 # Go workspace file
 go.work
+
+# Artifacts created by GoReleaser during release
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,65 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+brews:
+  -
+    name: fman
+
+    # GitHub/GitLab repository to push the formula to
+    tap:
+      # Repository owner template. (templateable)
+      owner: nore-dev
+
+      # Repository name. (templateable)
+      name: homebrew-tap
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    # GOARM to specify which 32-bit arm version to use if there are multiple
+    # versions from the build section. Brew formulas support only one 32-bit
+    # version.
+    # Default is 6 for all artifacts or each id if there a multiple versions.
+    goarm: "7"
+
+    # Template for the url which is determined by the given Token (github,
+    # gitlab or gitea)
+    #
+    # Default depends on the client.
+    url_template: "https://github.com/nore-dev/fman/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    # The project name and current git tag are used in the format string.
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://github.com/nore-dev/fman"
+
+    # Template of your app's description.
+    # Default is empty.
+    description: "Awesome TUI File Manager"
+
+    # SPDX identifier of your app's license.
+    # Default is empty.
+    license: "MIT"
+
+    # Setting this will prevent goreleaser to actually try to commit the updated
+    # formula - instead, the formula file will be stored on the dist folder only,
+    # leaving the responsibility of publishing it to the user.
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    # Default is false.
+    skip_upload: false
+
+    dependencies:
+      - name: go
 
 # modelines, feel free to remove those if you don't want/use them:
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ $ go install github.com/nore-dev/fman@latest
 $ npm i @nore-dev/fman
 ```
 
+### Brew
+
+```sh
+brew install fman/tap/fman
+```
+
 ## :keyboard: Keybindings
 
 |      Key      |                Description                |


### PR DESCRIPTION
**Scope:** 
- configured GoReleaser to publish to [homebrew](https://goreleaser.com/customization/homebrew/)

**Test:**

I didn't want to push a new tag and trigger a regular release so I could only test my changes by doing a `local-only` release with the command:
```sh
goreleaser release --snapshot --rm-dist
```

this generated `dist/fman.rb` formula file that would be published to [homebrew-tab](https://github.com/nore-dev/homebrew-tap) repo